### PR TITLE
Add CI/CD workflow

### DIFF
--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -1,11 +1,12 @@
 name: notebook-pr
-on: 
+on:
   pull_request:
     branches: main
     paths: '**/*.ipynb'
 
 env:
   NB_KERNEL: python
+  NMA_REPO: course-content-dl
   NMA_MAIN_BRANCH: main
 
 jobs:

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -1,0 +1,107 @@
+name: notebook-pr
+on: 
+  pull_request:
+    branches: main
+    paths: '**/*.ipynb'
+
+env:
+  NB_KERNEL: python
+  NMA_MAIN_BRANCH: main
+
+jobs:
+
+  process-notebooks:
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.head_ref }}
+
+      - name: Get commit message
+        run: |
+          readonly local msg=$(git log -1 --pretty=format:"%s")
+          echo "COMMIT_MESSAGE=$msg" >> $GITHUB_ENV
+
+      - name: Set up Python
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install CI tools
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        run: |
+          BRANCH=`python -c 'import os, re; m = re.search(r"nmaci:([\w-]+)", os.environ["COMMIT_MESSAGE"]); print("main" if m is None else m.group(1))'`
+          wget https://github.com/NeuromatchAcademy/nmaci/archive/refs/heads/$BRANCH.tar.gz
+          tar -xzf $BRANCH.tar.gz
+          python -m pip install --upgrade pip wheel
+          pip install -r nmaci-$BRANCH/requirements.txt
+          mv nmaci-$BRANCH/scripts/ ci/
+          rm -r nmaci-$BRANCH
+          echo ci/ >> .gitignore
+
+      - name: Install XKCD fonts
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        run: |
+          sudo apt-get update -yq
+          sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+          sudo apt-get install msttcorefonts -qq
+          rm -f $HOME/.matplotlib/fontList.cache
+
+      - name: Get changed files
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        id: changes
+        uses: trilom/file-changes-action@v1.2.4
+        with:
+          output: " "
+
+      - name: Process notebooks
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        id: process_notebooks
+        run: |
+          branch=${{ github.event.pull_request.head.ref }}
+          nbs=`python ci/select_notebooks.py ${{ steps.changes.outputs.files }}`
+          python ci/process_notebooks.py $nbs --check-execution
+          python ci/verify_exercises.py $nbs --c "$COMMIT_MESSAGE"
+          python ci/make_pr_comment.py $nbs --branch $branch --o comment.txt
+
+      - name: Add PR comment
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        uses: machine-learning-apps/pr-comment@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: comment.txt
+
+      # - name: Update READMEs
+      #   if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+      #   run: python ci/generate_tutorial_readmes.py
+
+      - name: Remove unreferenced derivatives
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci') && success()"
+        run: |
+          python ci/find_unreferenced_content.py > to_remove.txt
+          if [ -s to_remove.txt ]; then git rm --pathspec-from-file=to_remove.txt; fi
+
+      - name: Commit post-processed files
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci') && success()"
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add '**/*.ipynb'
+          git add '**/static/*.png'
+          git add '**/solutions/*.py'
+          git add '**/README.md'
+          git diff-index --quiet HEAD || git commit -m "Process tutorial notebooks"
+
+      - name: Push post-processed files
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci') && success()"
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}

--- a/.github/workflows/notebook-pr.yaml
+++ b/.github/workflows/notebook-pr.yaml
@@ -78,9 +78,9 @@ jobs:
         with:
           path: comment.txt
 
-      # - name: Update READMEs
-      #   if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
-      #   run: python ci/generate_tutorial_readmes.py
+      - name: Update READMEs
+        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        run: python ci/generate_tutorial_readmes.py
 
       - name: Remove unreferenced derivatives
         if: "!contains(env.COMMIT_MESSAGE, 'skip ci') && success()"


### PR DESCRIPTION
Mostly just copied from the CN repo.

Here's all I changed:

<details>

```diff
diff course-content/.github/workflows/notebook-pr.yaml course-content-dl/.github/workflows/notebook-pr.yaml
4c4
<     branches: master
---
>     branches: main
9c9
<   NMA_MAIN_BRANCH: master
---
>   NMA_MAIN_BRANCH: main
41a42
>           python -m pip install --upgrade pip wheel
47,52d47
<       - name: Install dependencies
<         if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
<         run: |
<           python -m pip install --upgrade pip wheel
<           pip install -r requirements.txt
<
74c69
<           python ci/process_notebooks.py $nbs --execute
---
>           python ci/process_notebooks.py $nbs --check-execution
```

</details>

Note this won't be fully functional until https://github.com/NeuromatchAcademy/nmaci/pull/6 lands.