### PR TITLE
Update publish-book.yaml

### DIFF
--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -44,7 +44,7 @@ jobs:
           pip install jupyter-book==0.10.2 ghp-import
       - name: Build the book
         run: |
-          python ci/generate_book.py
+          python ci/generate_book_dl.py
           ln -s ../tutorials book/tutorials
           ln -s ../projects book/projects
           jupyter-book build book


### PR DESCRIPTION
call generate_book_dl.py from nmaci to skip hardcoded projects chapter from nma-cn. to be changed in the future