### PR TITLE
tweak for tensorboard on kaggle

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -39,7 +39,7 @@ Slides: [Tutorial_1](https://mfr.ca-1.osf.io/render?url=https://osf.io/3qevp/?di
 
 ## W1D3 - Multi Layer Perceptrons
 
-[YouTube Playlist](https://youtube.com/playlist?list=PLkBQOLLbi18MGF3aRYZ-Ya_lexek248qJ)
+[YouTube Playlist](https://youtube.com/playlist?list=PLkBQOLLbi18NXk6yzEhjBJb92b6H0BNMw)
 
 Slides: [Tutorial_1](https://mfr.ca-1.osf.io/render?url=https://osf.io/ed65b/?direct%26mode=render%26action=download%26mode=render) | [Tutorial_2](https://mfr.ca-1.osf.io/render?url=https://osf.io/ed65b/?direct%26mode=render%26action=download%26mode=render)
 
@@ -189,6 +189,10 @@ Slides: [Tutorial_1](https://mfr.ca-1.osf.io/render?url=https://osf.io/3zn9w/?di
 
 
 ## W3D4 - Continual Learning
+
+[YouTube Playlist](https://youtube.com/playlist?list=PLkBQOLLbi18Mvz847jPl2T2bkXrfYyIC2)
+
+Slides: [Tutorial_1](https://mfr.ca-1.osf.io/render?url=https://osf.io/ejywm/?direct%26mode=render%26action=download%26mode=render) | [Tutorial_2](https://mfr.ca-1.osf.io/render?url=https://osf.io/dqnm6/?direct%26mode=render%26action=download%26mode=render)
 
 |   | Run | View |
 | - | --- | ---- |

--- a/tutorials/W2D4_AttentionAndTransformers/student/W2D4_Tutorial1.ipynb
+++ b/tutorials/W2D4_AttentionAndTransformers/student/W2D4_Tutorial1.ipynb
@@ -1758,7 +1758,8 @@
     "                                  num_train_epochs=1,  # students may use 5 to see a full training!\n",
     "                                  fp16=True,\n",
     "                                  save_steps=50,\n",
-    "                                  logging_steps=10\n",
+    "                                  logging_steps=10,\n",
+    "                                  report_to=\"tensorboard\"\n",
     "                                  )"
    ]
   },


### PR DESCRIPTION
change in section 8.3 for tensorboard to work on both kaggle and colab.

```python
# Setup huggingface trainer
training_args = TrainingArguments(output_dir="yelp_bert",
                                  overwrite_output_dir=True,
                                  evaluation_strategy="epoch",
                                  per_device_train_batch_size=64,
                                  per_device_eval_batch_size=64,
                                  learning_rate=5e-5,
                                  weight_decay=0.0,
                                  num_train_epochs=1,  # students may use 5 to see a full training!
                                  fp16=True,
                                  save_steps=50,
                                  logging_steps=10,
                                  report_to="tensorboard"
                                  )
```
added line: `report_to="tensorboard"`