### PR TITLE
Update publish-book.yaml

### DIFF
--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install CI tools
-        if: "!contains(env.COMMIT_MESSAGE, 'skip ci')"
+        if: "!contains(env.COMMIT_MESSAGE, 'skip book')"
         run: |
           BRANCH=`python -c 'import os, re; m = re.search(r"nmaci:([\w-]+)", os.environ["COMMIT_MESSAGE"]); print("main" if m is None else m.group(1))'`
           wget https://github.com/NeuromatchAcademy/nmaci/archive/refs/heads/$BRANCH.tar.gz


### PR DESCRIPTION
change 'skip ci' to 'skip book' if you want to not run the generate book workflow.