### PR TITLE
install tensorboard

### DIFF
--- a/tutorials/W2D4_AttentionAndTransformers/student/W2D4_Tutorial1.ipynb
+++ b/tutorials/W2D4_AttentionAndTransformers/student/W2D4_Tutorial1.ipynb
@@ -121,6 +121,7 @@
     "from IPython.display import clear_output\n",
     "\n",
     "!pip install textattack --quiet\n",
+    "!pip install tensorboard --quiet\n",
     "!pip install flair==0.6 --quiet\n",
     "!pip install datasets --quiet\n",
     "!pip install pytorch_pretrained_bert --quiet\n",


### PR DESCRIPTION
During the generate book workflow, an error occurred:

```python
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
/tmp/ipykernel_74968/2569646698.py in <module>
     30 from pytorch_pretrained_bert import BertTokenizer
     31 from pytorch_pretrained_bert import BertForMaskedLM
---> 32 get_ipython().run_line_magic('load_ext', 'tensorboard')

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/IPython/core/interactiveshell.py in run_line_magic(self, magic_name, line, _stack_depth)
   2362                 kwargs['local_ns'] = self.get_local_scope(stack_depth)
   2363             with self.builtin_trap:
-> 2364                 result = fn(*args, **kwargs)
   2365             return result
   2366 

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/decorator.py in fun(*args, **kw)
    230             if not kwsyntax:
    231                 args, kw = fix(args, kw, sig)
--> 232             return caller(func, *(extras + args), **kw)
    233     fun.__name__ = func.__name__
    234     fun.__doc__ = func.__doc__

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/IPython/core/magic.py in <lambda>(f, *a, **k)
    185     # but it's overkill for just that one bit of state.
    186     def magic_deco(arg):
--> 187         call = lambda f, *a, **k: f(*a, **k)
    188 
    189         if callable(arg):

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/IPython/core/magics/extension.py in load_ext(self, module_str)
     31         if not module_str:
     32             raise UsageError('Missing module name.')
---> 33         res = self.shell.extension_manager.load_extension(module_str)
     34 
     35         if res == 'already loaded':

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/IPython/core/extensions.py in load_extension(self, module_str)
     78             if module_str not in sys.modules:
     79                 with prepended_to_syspath(self.ipython_extension_dir):
---> 80                     mod = import_module(module_str)
     81                     if mod.__file__.startswith(self.ipython_extension_dir):
     82                         print(("Loading extensions from {dir} is deprecated. "

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/__init__.py in import_module(name, package)
    125                 break
    126             level += 1
--> 127     return _bootstrap._gcd_import(name[level:], package, level)
    128 
    129 

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/_bootstrap.py in _gcd_import(name, package, level)

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/_bootstrap.py in _find_and_load(name, import_)

/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/importlib/_bootstrap.py in _find_and_load_unlocked(name, import_)

ModuleNotFoundError: No module named 'tensorboard'
```

`!pip install tensorboard --quiet` may fix the issue.