### PR TITLE
Torch downgrade removed from W3D3 (NeuromatchAcademy#905)

### DIFF
--- a/tutorials/W3D3_UnsupervisedAndSelfSupervisedLearning/W3D3_Tutorial1.ipynb
+++ b/tutorials/W3D3_UnsupervisedAndSelfSupervisedLearning/W3D3_Tutorial1.ipynb
@@ -85,19 +85,6 @@
    },
    "outputs": [],
    "source": [
-    "# @title Downgrade `pytorch` to avoid CUDA Memory allocation error.\n",
-    "!pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 torchaudio==0.11.0 torchtext==0.12.0 --extra-index-url https://download.pytorch.org/whl/cu113 --quiet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
-   "outputs": [],
-   "source": [
     "# @title Install dependencies\n",
     "\n",
     "# @markdown Download dataset, modules, and files needed for the tutorial from GitHub.\n",
@@ -1009,7 +996,7 @@
     "```\n",
     "Network performance after 10 encoder and classifier training epochs (chance: 33.33%):\n",
     "    Training accuracy: 100.00%\n",
-    "    Testing accuracy: 98.67%\n",
+    "    Testing accuracy: 98.70%\n",
     "````"
    ]
   },
@@ -1082,7 +1069,7 @@
     "execution": {}
    },
    "source": [
-    "When the classifier is trained with an encoder network, however, it achieves very high classification accuracy (98.72%) on the test set, after only 10 training epochs."
+    "When the classifier is trained with an encoder network, however, it achieves very high classification accuracy (~98.70%) on the test set, after only 10 training epochs."
    ]
   },
   {
@@ -1095,7 +1082,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised |\n",
     "| - | - | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% |"
+    "| _33.33%_ |  | 39.55% | 98.70% |"
    ]
   },
   {
@@ -1956,7 +1943,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random |\n",
     "| - | - | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% |"
    ]
   },
   {
@@ -2532,7 +2519,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE |\n",
     "| - | - | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% |"
    ]
   },
   {
@@ -3163,7 +3150,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE | SimCLR |\n",
     "| - | - | --- | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% | 97.53% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% | 97.53% |"
    ]
   },
   {
@@ -4462,7 +4449,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE | SimCLR | SimCLR (few neg.pairs) |\n",
     "| - | - | --- | --- | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% | 97.53% | 66.75% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% | 97.53% | 66.75% |"
    ]
   },
   {

--- a/tutorials/W3D3_UnsupervisedAndSelfSupervisedLearning/instructor/W3D3_Tutorial1.ipynb
+++ b/tutorials/W3D3_UnsupervisedAndSelfSupervisedLearning/instructor/W3D3_Tutorial1.ipynb
@@ -85,19 +85,6 @@
    },
    "outputs": [],
    "source": [
-    "# @title Downgrade `pytorch` to avoid CUDA Memory allocation error.\n",
-    "!pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 torchaudio==0.11.0 torchtext==0.12.0 --extra-index-url https://download.pytorch.org/whl/cu113 --quiet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
-   "outputs": [],
-   "source": [
     "# @title Install dependencies\n",
     "\n",
     "# @markdown Download dataset, modules, and files needed for the tutorial from GitHub.\n",
@@ -1011,7 +998,7 @@
     "```\n",
     "Network performance after 10 encoder and classifier training epochs (chance: 33.33%):\n",
     "    Training accuracy: 100.00%\n",
-    "    Testing accuracy: 98.67%\n",
+    "    Testing accuracy: 98.70%\n",
     "````"
    ]
   },
@@ -1084,7 +1071,7 @@
     "execution": {}
    },
    "source": [
-    "When the classifier is trained with an encoder network, however, it achieves very high classification accuracy (98.72%) on the test set, after only 10 training epochs."
+    "When the classifier is trained with an encoder network, however, it achieves very high classification accuracy (~98.70%) on the test set, after only 10 training epochs."
    ]
   },
   {
@@ -1097,7 +1084,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised |\n",
     "| - | - | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% |"
+    "| _33.33%_ |  | 39.55% | 98.70% |"
    ]
   },
   {
@@ -1964,7 +1951,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random |\n",
     "| - | - | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% |"
    ]
   },
   {
@@ -2542,7 +2529,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE |\n",
     "| - | - | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% |"
    ]
   },
   {
@@ -3175,7 +3162,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE | SimCLR |\n",
     "| - | - | --- | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% | 97.53% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% | 97.53% |"
    ]
   },
   {
@@ -4476,7 +4463,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE | SimCLR | SimCLR (few neg.pairs) |\n",
     "| - | - | --- | --- | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% | 97.53% | 66.75% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% | 97.53% | 66.75% |"
    ]
   },
   {

--- a/tutorials/W3D3_UnsupervisedAndSelfSupervisedLearning/student/W3D3_Tutorial1.ipynb
+++ b/tutorials/W3D3_UnsupervisedAndSelfSupervisedLearning/student/W3D3_Tutorial1.ipynb
@@ -85,19 +85,6 @@
    },
    "outputs": [],
    "source": [
-    "# @title Downgrade `pytorch` to avoid CUDA Memory allocation error.\n",
-    "!pip install torch==1.11.0+cu113 torchvision==0.12.0+cu113 torchaudio==0.11.0 torchtext==0.12.0 --extra-index-url https://download.pytorch.org/whl/cu113 --quiet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "cellView": "form",
-    "execution": {}
-   },
-   "outputs": [],
-   "source": [
     "# @title Install dependencies\n",
     "\n",
     "# @markdown Download dataset, modules, and files needed for the tutorial from GitHub.\n",
@@ -1009,7 +996,7 @@
     "```\n",
     "Network performance after 10 encoder and classifier training epochs (chance: 33.33%):\n",
     "    Training accuracy: 100.00%\n",
-    "    Testing accuracy: 98.67%\n",
+    "    Testing accuracy: 98.70%\n",
     "````"
    ]
   },
@@ -1043,7 +1030,7 @@
     "execution": {}
    },
    "source": [
-    "When the classifier is trained with an encoder network, however, it achieves very high classification accuracy (98.72%) on the test set, after only 10 training epochs."
+    "When the classifier is trained with an encoder network, however, it achieves very high classification accuracy (~98.70%) on the test set, after only 10 training epochs."
    ]
   },
   {
@@ -1056,7 +1043,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised |\n",
     "| - | - | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% |"
+    "| _33.33%_ |  | 39.55% | 98.70% |"
    ]
   },
   {
@@ -1757,7 +1744,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random |\n",
     "| - | - | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% |"
    ]
   },
   {
@@ -2226,7 +2213,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE |\n",
     "| - | - | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% |"
    ]
   },
   {
@@ -2791,7 +2778,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE | SimCLR |\n",
     "| - | - | --- | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% | 97.53% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% | 97.53% |"
    ]
   },
   {
@@ -3856,7 +3843,7 @@
     "\n",
     "| _Chance_ |  | None (raw data) | Supervised | Random | VAE | SimCLR | SimCLR (few neg.pairs) |\n",
     "| - | - | --- | --- | --- | --- | --- | --- |\n",
-    "| _33.33%_ |  | 39.55% | 98.67% | 44.67% | 45.75% | 97.53% | 66.75% |"
+    "| _33.33%_ |  | 39.55% | 98.70% | 44.67% | 45.75% | 97.53% | 66.75% |"
    ]
   },
   {


### PR DESCRIPTION
This commit fixes issue #905. `torch 2.0` introduced an out of memory bug in the tutorial, which was addressed with commit ed8f9f2 by downgrading to `torch 1.11`. The pytorch bug was fixed in `torch 2.1` through commit [fff4a9](https://github.com/pytorch/pytorch/commit/fff4a9db8a28553ba80915fd22eec11fcd7c855e). Since Google Colab now comes with `torch 2.1` installed by default, the downgrade is no longer needed.

I also changed the supervised learning performance reported in table from `98.67%` to `98.70%`. Unlike the other methods (VAE, SimCLR, etc.), the supervised result has never been perfectly identical on each run. It varies a little bit around `98.70%` (from `98.67%` to `98.73%`, when I've run it). To avoid confusion for users, the first time this result is reported, it is now reported with a `~` (i.e., as `~98.70%`) to signal to users that their result may differ slightly from it.