### PR TITLE
W3D2: fix video title renaming inconsistency

### DIFF
--- a/tutorials/W3D2_DLCaseStudy2/W3D2_Tutorial1.ipynb
+++ b/tutorials/W3D2_DLCaseStudy2/W3D2_Tutorial1.ipynb
@@ -1235,7 +1235,7 @@
    },
    "outputs": [],
    "source": [
-    "# @title Video 10: Wrap-up of DL Case Study\n",
+    "# @title Video 10: Wrap-up of DL Case Study 2\n",
     "from ipywidgets import widgets\n",
     "from IPython.display import YouTubeVideo\n",
     "from IPython.display import IFrame\n",
@@ -1292,7 +1292,7 @@
    "outputs": [],
    "source": [
     "# @title Submit your feedback\n",
-    "content_review(f\"{feedback_prefix}_WrapUp_of_DL_Case_Study_Video\")"
+    "content_review(f\"{feedback_prefix}_WrapUp_of_DL_Case_Study2_Video\")"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fixes inconsistent video titles in W3D2_Tutorial1 following the rename from DlThinking2 to DLCaseStudy2 (follow-up to #1020)

## Test plan
- [ ] Verify video cell titles in W3D2_Tutorial1.ipynb reflect the new DL Case Study naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)